### PR TITLE
Switch fetching from parallel to serial

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Attach to Process",
+			"type": "go",
+			"request": "attach",
+			"mode": "local",
+			"processId": 0
+		},
+		{
+			"name": "Connect to server",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"remotePath": "${workspaceFolder}",
+			"port": 2345,
+			"host": "127.0.0.1"
+		},
+		{
+			"name": "Launch program",
+			"type": "go",
+			"request": "launch",
+			"mode": "debug",
+			"program": "${workspaceFolder}",
+			"args": [
+				"-uri=https://www.bilimma.com/sitemap.xml",
+				"-index"
+			]
+		}
+	]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module sitemap-checker
+
+go 1.13
+
+require (
+)


### PR DESCRIPTION
Website disallows multiple downloads.
So go routine fails on multiple `GET` requests.
I changed go routine to normal loop.
That is, parallel became serial.